### PR TITLE
Close tm-7la: Talmud engine exploration

### DIFF
--- a/issues/closed/tm-7la-explore-reusing-this-engine-for-the-talmud.md
+++ b/issues/closed/tm-7la-explore-reusing-this-engine-for-the-talmud.md
@@ -1,6 +1,7 @@
 ---
 id: tm-7la
-status: open
+status: closed
+closed: 2026-04-07
 priority: 4
 type: feature
 created: 2026-01-10


### PR DESCRIPTION
## Summary
- Close tm-7la. The exploration shipped in PR #11 (design doc, memo, reference render, 13 follow-up issues, Hebrew/Aramaic classifier prototype).
- This PR just moves the issue file from `issues/open/` to `issues/closed/` and updates its frontmatter — the only thing `land-issue.sh` couldn't push directly because main now requires PRs.

## Test plan
- [x] `npm test` — 1406 tests pass