### PR TITLE
land-issue.sh: open PR instead of merging to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,34 +89,39 @@ This script will:
 
 1. Verify no uncommitted changes
 2. Move `issues/open/<id>-*.md` → `issues/closed/` and commit (on the feature branch)
-3. Pull latest main, merge the feature branch, push
-4. Remove the worktree
-5. Delete the local feature branch (use `--keep-branch` to skip)
+3. Push the feature branch and open a PR against main via `gh`
 
-**DO NOT try to merge manually** — use `land-issue.sh` so the issue file gets moved to `closed/` consistently.
+Main is protected and requires PRs, so **Danyel merges the PR manually**. After
+the merge lands, clean up the worktree:
+
+```bash
+cd <main repo> && git worktree remove ../torahmap-worktrees/<id> && git branch -D <id>
+```
+
+**DO NOT try to merge locally** — use `land-issue.sh` so the issue file gets moved to `closed/` consistently and the PR gets opened.
 
 ## Landing the Plane (Session Completion)
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+**When ending a work session**, you MUST complete ALL steps below. Work on an issue is NOT complete until a PR is open against main. (Main is protected — Danyel merges the PR manually.)
 
 1. **File issues for remaining work** — `./scripts/issues-new.sh "Title"` for anything that needs follow-up
 2. **Run quality gates** (if code changed) — `npm test`, build, etc.
-3. **Update issue status** — close finished work by moving the file to `issues/closed/`
-4. **PUSH TO REMOTE** — mandatory:
+3. **Update issue status** — close finished work by moving the file to `issues/closed/` (or let `land-issue.sh` do it)
+4. **OPEN A PR** — mandatory. From inside the worktree:
    ```bash
-   git pull --rebase
-   git push
-   git status   # MUST show "up to date with origin"
+   ./scripts/land-issue.sh
    ```
-5. **Clean up** — clear stashes, prune remote branches
-6. **Verify** — all changes committed AND pushed
+   This pushes the feature branch and opens a PR. Confirm the PR URL is printed.
+5. **Verify** — branch pushed AND PR open against main. `gh pr view` should show it.
 
 **CRITICAL RULES:**
 
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing — that leaves work stranded locally
-- NEVER say "ready to push when you are" — YOU must push
-- If push fails, resolve and retry until it succeeds
+- Work is NOT complete until a PR is open against main
+- NEVER stop before running `land-issue.sh` — that leaves work stranded locally
+- NEVER say "ready to push when you are" — YOU must push and open the PR
+- NEVER try to push directly to main — it's protected
+- If push or PR creation fails, resolve and retry until it succeeds
+- Worktree cleanup happens AFTER Danyel merges the PR, not before
 
 ## Why not beads?
 

--- a/scripts/land-issue.sh
+++ b/scripts/land-issue.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# Usage: land-issue.sh [--keep-branch]
-# Run from inside a worktree. Merges the worktree's branch into main, closes
-# the issue (moves issues/open/<id>-*.md -> issues/closed/), pushes, cleans up.
+# Usage: land-issue.sh
+# Run from inside a worktree. Closes the issue (moves issues/open/<id>-*.md ->
+# issues/closed/), pushes the feature branch, and opens a PR against main.
+# Main is protected — you merge the PR yourself.
 set -e
-
-KEEP_BRANCH=false
-[[ "${1:-}" == "--keep-branch" ]] && KEEP_BRANCH=true
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BRANCH_NAME=$(git branch --show-current)
@@ -57,26 +55,29 @@ else
   echo "Note: no issue file matched issues/open/${ISSUE_ID}-*.md (skipping close step)"
 fi
 
-# 4. Switch to main repo, pull, merge, push
-cd "$MAIN_REPO"
-echo "Pulling latest from origin..."
-git pull --rebase
+# 4. Push feature branch
+echo "Pushing $BRANCH_NAME..."
+git push -u origin "$BRANCH_NAME"
 
-echo "Merging $BRANCH_NAME into main..."
-git merge "$BRANCH_NAME" --no-edit
-
-echo "Pushing..."
-git push
-
-# 5. Clean up worktree
-echo "Removing worktree $REPO_ROOT..."
-git worktree remove "$REPO_ROOT"
-
-# 6. Optionally delete branch
-if ! $KEEP_BRANCH; then
-  git branch -d "$BRANCH_NAME"
-  echo "Deleted branch $BRANCH_NAME"
+# 5. Open a PR against main (if one doesn't already exist)
+existing_pr=$(gh pr view "$BRANCH_NAME" --json url --jq .url 2>/dev/null || true)
+if [[ -n "$existing_pr" ]]; then
+  echo "PR already exists: $existing_pr"
+else
+  # Title: prefer the issue file's H1; fall back to the branch name
+  pr_title="$ISSUE_ID"
+  if (( ${#issue_files[@]} == 1 )); then
+    h1=$(grep -m1 '^# ' "$dst" | sed 's/^# //')
+    [[ -n "$h1" ]] && pr_title="$ISSUE_ID: $h1"
+  fi
+  echo "Opening PR..."
+  gh pr create \
+    --base main \
+    --head "$BRANCH_NAME" \
+    --title "$pr_title" \
+    --body "Closes \`$ISSUE_ID\`."
 fi
 
 echo ""
-echo "Landed $ISSUE_ID. You are now in $MAIN_REPO"
+echo "$ISSUE_ID: branch pushed and PR open. Merge it yourself, then run:"
+echo "  cd $MAIN_REPO && git worktree remove $REPO_ROOT && git branch -D $BRANCH_NAME"


### PR DESCRIPTION
## Summary
- Rewrites `scripts/land-issue.sh` to push the feature branch and open a PR via `gh` instead of merging to main directly (main is protected, so the old flow broke).
- Updates `AGENTS.md` so the "Landing the Plane" checklist matches: PR open is now the completion bar, and worktree cleanup happens after Danyel merges.

## Test plan
- [ ] Next worktree-based issue lands cleanly via `./scripts/land-issue.sh` and produces a PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)