### PR TITLE
Add demo recording tooling + concept gallery index

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,27 @@ Overlays:
 - Text Search:
 - Trop (Canitillation):
 - Divine Names:
+
+## Visual Concept Demos
+
+A set of ten visual experiments built as parallel agent worktrees. None ship in
+the live app — they're preserved here so future demos can cherry-pick from
+them. Source code is on the `demo/*` branches; ~30s 1080p recordings are on
+the orphan [`demo-gallery`](../../tree/demo-gallery) branch.
+
+| Concept | Source | Video |
+|---|---|---|
+| **Breathing Text** — proximity reveals first Hebrew word of nearby verses on hover | [`demo/breathing-text`](../../tree/demo/breathing-text) | [.webm](../../blob/demo-gallery/videos/breathing-text.webm) |
+| **Gematria Constellations** — hover draws lines to verses with matching numerical value | [`demo/gematria-constellations`](../../tree/demo/gematria-constellations) | [.webm](../../blob/demo-gallery/videos/gematria-constellations.webm) |
+| **Heat Shimmer** — subtle ambient brightness oscillation, per-verse | [`demo/heat-shimmer`](../../tree/demo/heat-shimmer) | [.webm](../../blob/demo-gallery/videos/heat-shimmer.webm) |
+| **Manuscript Watermarks** — illuminated parsha / section / chapter layers | [`demo/manuscript-watermarks`](../../tree/demo/manuscript-watermarks) | [.webm](../../blob/demo-gallery/videos/manuscript-watermarks.webm) |
+| **Ripple Words** — concentric wave on hover reveals first word of ~15 nearby verses | [`demo/ripple-words`](../../tree/demo/ripple-words) | [.webm](../../blob/demo-gallery/videos/ripple-words.webm) |
+| **Scatter Hover** — gentle jostle effect on hover | [`demo/scatter-hover`](../../tree/demo/scatter-hover) | [.webm](../../blob/demo-gallery/videos/scatter-hover.webm) |
+| **Thread Lines** — connections between verses sharing rare words | [`demo/thread-lines`](../../tree/demo/thread-lines) | [.webm](../../blob/demo-gallery/videos/thread-lines.webm) |
+| **Torah Rain** — ambient falling Hebrew characters | [`demo/torah-rain`](../../tree/demo/torah-rain) | [.webm](../../blob/demo-gallery/videos/torah-rain.webm) |
+| **Verse Whisper** — calligraphic Hebrew text reveal on hover | [`demo/verse-whisper`](../../tree/demo/verse-whisper) | [.webm](../../blob/demo-gallery/videos/verse-whisper.webm) |
+| **Word Clouds** — multi-scale word clouds that refine as you zoom in | [`demo/word-clouds`](../../tree/demo/word-clouds) | [.webm](../../blob/demo-gallery/videos/word-clouds.webm) |
+
+The recording tooling that produced the videos lives at
+[`scripts/demo/`](scripts/demo/) — see its README for the workflow if you want
+to add a new concept or refresh an existing recording.

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,54 @@
+# Demo Recording Tooling
+
+Captures ~30s 1080p webm recordings of the visual concepts living on the
+`demo/*` branches. The recordings themselves are stored on the orphan
+[`demo-gallery`](../../tree/demo-gallery) branch.
+
+## Workflow
+
+1. Each `demo/<name>` branch is checked out as a worktree under
+   `.claude/worktrees/agent-<hash>/`. The worktree must have working
+   `node_modules` (specifically `vite` and `playwright`).
+2. `record-concept.mjs` launches Playwright headlessly, navigates to the
+   running dev server, drives a scripted camera + cursor path, then
+   2-pass re-encodes the captured webm to a higher bitrate via Playwright's
+   bundled ffmpeg. Output: `.claude/videos/<name>.webm`.
+3. `record-all.sh` walks every concept, starts/stops vite per worktree,
+   and applies a per-concept env recipe so each effect actually shows up
+   (subtle ones like heat-shimmer need deeper zoom; hover-driven ones
+   need cursor sweeping).
+
+## Usage
+
+```bash
+# Whole gallery
+./scripts/demo/record-all.sh
+
+# Single concept (vite must be running on :5173)
+node scripts/demo/record-concept.mjs torah-rain
+HOVER_SWEEP=1 node scripts/demo/record-concept.mjs ripple-words
+PHASE1_MS=3000 ZOOM_TICKS=24 PHASE3_MS=20000 \
+    node scripts/demo/record-concept.mjs heat-shimmer
+```
+
+## Tunables
+
+| Env | Default | Notes |
+|---|---|---|
+| `HOVER_SWEEP` | `0` | `1` = wander cursor every 1.5s during phases 1+3. Needed for hover-driven effects. |
+| `ZOOM_TICKS` | `15` | Wheel ticks during phase 2. Each tick = ×1.1 zoom. |
+| `PHASE1_MS` | `12000` | Time held at default zoom. |
+| `PHASE3_MS` | `14250` | Time held after zoom. |
+
+## Notes
+
+- Recordings are 1920×1080 at 25fps. The 2-pass libvpx re-encode targets
+  10 Mbps with relaxed quantizer bounds and a 1s keyframe interval —
+  needed because animated content breaks libvpx's still-frame heuristics
+  and the default rate becomes ~880 kbps which crushes subtle effects.
+- The recorder reuses Playwright from whichever worktree has it under
+  `node_modules/`, so you don't need a project-level Playwright install.
+- Headless chromium runs the WebGL shaders correctly (verified by
+  pixel-diffing two screenshots 2s apart on heat-shimmer); the only
+  visibility issue at 1.0× zoom is compression flattening sub-10%
+  brightness deltas, which the deep-zoom recipe works around.

--- a/scripts/demo/record-all.sh
+++ b/scripts/demo/record-all.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Record a 30s clip from every demo/* concept worktree using record-concept.mjs.
+#
+# Assumes:
+#   - Each demo/<name> branch has a worktree at .claude/worktrees/agent-*/
+#     with a working node_modules (vite, playwright).
+#   - Port 5173 is free (script waits between runs for it to release).
+#
+# Concept-specific recipes:
+#   - heat-shimmer (subtle ±7% brightness): deeper zoom + longer hold.
+#   - hover-driven effects (ripple, scatter, whisper, constellations,
+#     thread-lines, breathing-text): HOVER_SWEEP=1 to retrigger.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKTREES_DIR="$REPO/.claude/worktrees"
+RECORDER="$SCRIPT_DIR/record-concept.mjs"
+
+# Format: <worktree-suffix>:<output-name>:<extra env vars>
+# The extra env field is passed verbatim to `env`.
+CONCEPTS=(
+    "agent-a89ba747:torah-rain:"
+    "agent-a4b508f6:heat-shimmer:PHASE1_MS=3000 ZOOM_TICKS=24 PHASE3_MS=20000"
+    "agent-a5db4894:manuscript-watermarks:"
+    "agent-a8477d1d:breathing-text:HOVER_SWEEP=1"
+    "agent-abd92801:word-clouds:"
+    "agent-a169c835:gematria-constellations:HOVER_SWEEP=1"
+    "agent-a668fd1f:scatter-hover:HOVER_SWEEP=1"
+    "agent-a8e243ad:verse-whisper:HOVER_SWEEP=1"
+    "agent-a9c47786:thread-lines:HOVER_SWEEP=1"
+    "agent-a37243aa:ripple-words:HOVER_SWEEP=1"
+)
+
+wait_for_port_free() {
+    local tries=0
+    while lsof -i :5173 -sTCP:LISTEN -t >/dev/null 2>&1; do
+        ((tries++))
+        if ((tries > 15)); then
+            echo "  port 5173 still busy after 15s — bailing"
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+wait_for_http() {
+    for _ in {1..30}; do
+        if [[ "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5173/)" == "200" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+for entry in "${CONCEPTS[@]}"; do
+    IFS=':' read -r dir name extra_env <<< "$entry"
+    wt="$WORKTREES_DIR/$dir"
+
+    echo ""
+    echo "===== $name ($dir) ====="
+    [[ -n "$extra_env" ]] && echo "  env: $extra_env"
+
+    if [[ ! -x "$wt/node_modules/.bin/vite" ]]; then
+        echo "  SKIP: $wt has no vite in node_modules"
+        continue
+    fi
+
+    wait_for_port_free || continue
+
+    pushd "$wt" >/dev/null
+    node ./node_modules/.bin/vite > "/tmp/vite-$name.log" 2>&1 &
+    VITE_PID=$!
+    popd >/dev/null
+
+    if ! wait_for_http; then
+        echo "  FAIL: vite never returned 200"
+        tail -20 "/tmp/vite-$name.log"
+        kill "$VITE_PID" 2>/dev/null
+        continue
+    fi
+
+    if env $extra_env node "$RECORDER" "$name"; then
+        echo "  ✓ recorded $name"
+    else
+        echo "  ✗ recorder failed for $name"
+    fi
+
+    kill "$VITE_PID" 2>/dev/null
+    sleep 1
+done
+
+echo ""
+echo "===== summary ====="
+ls -lh "$REPO/.claude/videos/"*.webm 2>/dev/null

--- a/scripts/demo/record-concept.mjs
+++ b/scripts/demo/record-concept.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Record a ~30s clip of a torahmap dev server. Used to capture visual
+// concepts living on demo/* branches into webms on the demo-gallery branch.
+//
+// Usage:
+//   node scripts/demo/record-concept.mjs <name> [url]
+//     <name>  output basename (e.g. "torah-rain")
+//     [url]   defaults to http://localhost:5173
+//
+// Tunable env vars:
+//   HOVER_SWEEP=1      Wander cursor across nearby verses to retrigger
+//                      hover-driven effects (ripples, scatter, etc.)
+//   ZOOM_TICKS=N       Wheel ticks during phase 2 (default 15 ≈ 4.2x;
+//                      heat-shimmer used 24 ≈ 9.8x).
+//   PHASE1_MS=N        Duration of zoomed-out phase (default 12000).
+//   PHASE3_MS=N        Duration of zoomed-in hold (default 14250).
+//
+// Resolves Playwright from any worktree under .claude/worktrees/ that has
+// it installed (each demo/* branch's worktree typically does). Writes to
+// .claude/videos/<name>.webm.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(here, "..", "..");
+const videosDir = join(repo, ".claude", "videos");
+mkdirSync(videosDir, { recursive: true });
+
+const name = process.argv[2];
+if (!name) {
+  console.error("usage: record-concept.mjs <name> [url]");
+  process.exit(2);
+}
+const url = process.argv[3] || "http://localhost:5173/";
+const outWebm = join(videosDir, `${name}.webm`);
+
+// Find a worktree with Playwright installed and resolve from there.
+const worktreesRoot = join(repo, ".claude", "worktrees");
+const candidate = existsSync(worktreesRoot)
+  ? readdirSync(worktreesRoot)
+      .map((d) => join(worktreesRoot, d, "node_modules", "playwright"))
+      .find((p) => existsSync(p))
+  : undefined;
+if (!candidate) {
+  console.error(
+    `No worktree under ${worktreesRoot} has playwright installed under node_modules/`,
+  );
+  process.exit(1);
+}
+const require = createRequire(join(candidate, "package.json"));
+const { chromium } = require("playwright");
+
+console.log(`recording ${url} → ${outWebm}`);
+
+const stagingDir = join(videosDir, `.tmp-${name}-${Date.now()}`);
+mkdirSync(stagingDir, { recursive: true });
+
+const VIEWPORT = { width: 1920, height: 1080 };
+
+const browser = await chromium.launch({
+  headless: true,
+  args: ["--headless=new", "--no-sandbox"],
+});
+const context = await browser.newContext({
+  viewport: VIEWPORT,
+  deviceScaleFactor: 1,
+  recordVideo: { dir: stagingDir, size: VIEWPORT },
+});
+
+// Suppress the first-visit help modal (see src/help.ts STORAGE_KEY_SEEN).
+await context.addInitScript(() => {
+  try {
+    localStorage.setItem("torahMap.helpSeen", "true");
+  } catch {}
+});
+
+const page = await context.newPage();
+
+await page.goto(url, { waitUntil: "domcontentloaded" });
+// Give WebGL/canvases a moment to initialize before the demo begins.
+await page.waitForTimeout(2000);
+
+// Anchor the zoom on the Torah strip near the top of the viewport.
+// Each wheel tick = 1.1x zoom (see src/constants/app.ts ZOOM_IN_FACTOR).
+const cx = VIEWPORT.width / 2;
+const torahY = Math.round(VIEWPORT.height * 0.18);
+await page.mouse.move(cx, torahY);
+
+// HOVER_SWEEP=1: between the zoom phases, wander the cursor across nearby
+// verses on a regular cadence so hover-triggered effects (ripples, scatter,
+// constellations, etc.) actually fire repeatedly instead of just once.
+const hoverSweep = process.env.HOVER_SWEEP === "1";
+async function sweep(durationMs, anchorY) {
+  if (!hoverSweep) {
+    await page.waitForTimeout(durationMs);
+    return;
+  }
+  const interval = 1500;
+  const ticks = Math.floor(durationMs / interval);
+  for (let i = 0; i < ticks; i++) {
+    const x = VIEWPORT.width * (0.2 + Math.random() * 0.6);
+    const y = anchorY + (Math.random() - 0.5) * 80;
+    await page.mouse.move(x, y, { steps: 8 });
+    await page.waitForTimeout(interval);
+  }
+  // Park back at the anchor before zoom.
+  await page.mouse.move(cx, anchorY);
+}
+
+// Phase durations are tunable via env. Defaults give ~30s total.
+const phase1Ms = parseInt(process.env.PHASE1_MS ?? "12000", 10);
+const phase3Ms = parseInt(process.env.PHASE3_MS ?? "14250", 10);
+
+console.log(`phase 1: zoomed out (${(phase1Ms / 1000).toFixed(2)}s)${hoverSweep ? " + hover sweep" : ""}`);
+await sweep(phase1Ms, torahY);
+
+const zoomTicks = parseInt(process.env.ZOOM_TICKS ?? "15", 10);
+const tickInterval = 250;
+const phase2Ms = zoomTicks * tickInterval;
+console.log(`phase 2: zooming in (${zoomTicks} ticks, ${(phase2Ms / 1000).toFixed(2)}s)`);
+for (let i = 0; i < zoomTicks; i++) {
+  await page.mouse.wheel(0, -120);
+  await page.waitForTimeout(tickInterval);
+}
+
+console.log(`phase 3: zoomed in (${(phase3Ms / 1000).toFixed(2)}s)${hoverSweep ? " + hover sweep" : ""}`);
+await sweep(phase3Ms, torahY);
+
+await page.close();
+await context.close();
+await browser.close();
+
+const produced = readdirSync(stagingDir).filter((f) => f.endsWith(".webm"));
+if (produced.length !== 1) {
+  console.error(`expected 1 webm in ${stagingDir}, got ${produced.length}`);
+  process.exit(1);
+}
+if (existsSync(outWebm)) rmSync(outWebm);
+renameSync(join(stagingDir, produced[0]), outWebm);
+rmSync(stagingDir, { recursive: true, force: true });
+
+console.log(`saved → ${outWebm}`);
+
+// 2-pass re-encode at higher VP8 bitrate. Playwright's bundled ffmpeg is
+// stripped (VP8 only — no H.264) but does the job. Animated content (rain,
+// fades, shimmer) needs the higher bitrate + relaxed quantizer bounds + 1s
+// keyframe interval — the encoder's still-frame heuristics under-allocate
+// otherwise.
+const ffmpeg = join(
+  process.env.HOME,
+  "Library/Caches/ms-playwright/ffmpeg-1011/ffmpeg-mac",
+);
+if (existsSync(ffmpeg)) {
+  const tmpHq = join(videosDir, `.hq-${name}-${Date.now()}.webm`);
+  const passLogPrefix = join(videosDir, `.passlog-${name}-${Date.now()}`);
+
+  const sharedArgs = [
+    "-hide_banner",
+    "-loglevel", "warning",
+    "-y",
+    "-i", outWebm,
+    "-c:v", "libvpx",
+    "-b:v", "10M",
+    "-maxrate", "14M",
+    "-bufsize", "20M",
+    "-qmin", "0",
+    "-qmax", "50",
+    "-quality", "best",
+    "-cpu-used", "0",
+    "-g", "25",
+    "-passlogfile", passLogPrefix,
+    "-an",
+  ];
+
+  console.log("re-encoding webm @ 10 Mbps VP8 (2-pass)...");
+  const pass1 = spawnSync(
+    ffmpeg,
+    [...sharedArgs, "-pass", "1", "-f", "webm", "/dev/null"],
+    { stdio: "inherit" },
+  );
+  let pass2Status = -1;
+  if (pass1.status === 0) {
+    const pass2 = spawnSync(
+      ffmpeg,
+      [...sharedArgs, "-pass", "2", tmpHq],
+      { stdio: "inherit" },
+    );
+    pass2Status = pass2.status ?? -1;
+  }
+
+  for (const suffix of ["-0.log", "-0.log.mbtree"]) {
+    const p = `${passLogPrefix}${suffix}`;
+    if (existsSync(p)) rmSync(p);
+  }
+
+  if (pass1.status === 0 && pass2Status === 0 && existsSync(tmpHq)) {
+    rmSync(outWebm);
+    renameSync(tmpHq, outWebm);
+    console.log(`upgraded → ${outWebm}`);
+  } else {
+    if (existsSync(tmpHq)) rmSync(tmpHq);
+    console.warn(
+      `ffmpeg pass1=${pass1.status} pass2=${pass2Status} — keeping original webm`,
+    );
+  }
+} else {
+  console.warn("bundled ffmpeg not found — skipping re-encode");
+}


### PR DESCRIPTION
## Summary

Captures and preserves the ten visual experiments that were sitting in agent worktrees, so future demos can pull from them.

- **`scripts/demo/`**: the recorder (`record-concept.mjs`), the per-concept batch runner (`record-all.sh`), and a README. Drives Playwright headlessly, scripts a zoom path + optional cursor sweep, 2-pass re-encodes via Playwright's bundled ffmpeg.
- **`README.md`**: new "Visual Concept Demos" section indexes ten `demo/*` branches alongside their recordings on the orphan `demo-gallery` branch.

## Branches landed alongside this PR

- 10× `demo/<name>` source branches (already pushed)
- 1× `demo-gallery` orphan branch with all ten ~30s 1080p webms (already pushed, ~286MB)

Neither is intended to merge — the demo branches preserve the source, and the gallery isolates the binaries from main's history.

## Test plan

- [ ] Verify the README table renders correctly on GitHub (links resolve to the right tree/blob URLs)
- [ ] Verify `scripts/demo/record-all.sh` finds vite + playwright in worktrees and produces `.claude/videos/*.webm`
- [ ] Spot-check one or two videos still play after the demo-gallery push round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)