### PR TITLE
Make the pre-commit hook actually run the tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -41,6 +41,16 @@ if [ ! -d node_modules ] || [ ! -x node_modules/.bin/vitest ]; then
   Then commit again."
 fi
 
+# The typecheck and the tests are run as two separate steps rather than through
+# the composite `npm run test:ci`, deliberately. This hook's whole job is to
+# tell whoever is committing what went wrong, and running the stages separately
+# is what lets it say which one failed; test:ci collapses both into a single
+# exit code. The two also announce themselves as they start, so a commit that
+# pauses for several seconds does not look hung.
+#
+# This is not duplication that can drift: test:ci and this hook are both
+# defined in terms of the same `typecheck` and `test` scripts, so redefining
+# either one flows through to both.
 echo "pre-commit: typechecking..."
 if ! npm run --silent typecheck; then
   fail "Type errors. See the tsc output above."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+#
+# Torah Map pre-commit gate.
+#
+# Runs the type checker and the full test suite before every commit and
+# refuses the commit if either fails. Together they take about six seconds.
+#
+# This file is tracked in git. It runs because core.hooksPath points at
+# .githooks (see scripts/install-hooks.sh). Because that path is relative,
+# every git worktree runs the copy checked out on its own branch.
+#
+# To skip deliberately:  git commit --no-verify
+
+set -u
+
+# Run from the top of whichever worktree is committing.
+repo_root=$(git rev-parse --show-toplevel) || exit 1
+cd "$repo_root" || exit 1
+
+fail() {
+  echo ""
+  echo "  COMMIT BLOCKED --------------------------------------------------"
+  echo "  $1"
+  echo ""
+  echo "  Fix it, or bypass deliberately with: git commit --no-verify"
+  echo "  -----------------------------------------------------------------"
+  echo ""
+  exit 1
+}
+
+# Dependencies missing is the single most common cause of confusing failures
+# here: a fresh worktree has no node_modules, and the type checker then reports
+# "Cannot find type definition file for 'vite/client'", which reads like a code
+# error but is not. Catch it up front and say so plainly.
+if [ ! -d node_modules ] || [ ! -x node_modules/.bin/vitest ]; then
+  fail "Dependencies are not installed in this worktree, so the tests and
+  type checker cannot run. This is not a problem with your code.
+
+      cd $repo_root && npm install
+
+  Then commit again."
+fi
+
+echo "pre-commit: typechecking..."
+if ! npm run --silent typecheck; then
+  fail "Type errors. See the tsc output above."
+fi
+
+echo "pre-commit: running tests..."
+if ! npm run --silent test; then
+  fail "Tests failed. See the vitest output above."
+fi
+
+echo "pre-commit: typecheck and tests passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,36 @@ npm run test:watch    # Watch mode for development
 npm run test:coverage # Coverage report
 ```
 
-A pre-commit hook automatically runs all tests. To bypass (not recommended): `git commit --no-verify`
+### The pre-commit hook
+
+A pre-commit hook runs `npm run typecheck` and the full test suite, and refuses
+the commit if either fails. The two together take about six seconds.
+
+The hook lives in `.githooks/pre-commit`, which is tracked in git. Git only
+looks there once `core.hooksPath` is set, and that setting is local to your
+clone — it cannot travel in a commit. **After cloning, run this once:**
+
+```bash
+./scripts/install-hooks.sh          # same as: git config core.hooksPath .githooks
+```
+
+It is also wired to npm's `prepare` script, so plain `npm install` usually does
+it for you. Do not count on that: if your npm config sets `ignore-scripts=true`
+(a reasonable supply-chain precaution, and the setting on Danyel's machine),
+npm skips `prepare` silently and you must run the script yourself. Running it
+twice is harmless.
+
+The path is stored as the relative string `.githooks`, which git resolves
+against whichever working tree is committing. One setting therefore covers the
+main checkout and every worktree, and each runs the hook checked out on its own
+branch. A branch that predates `.githooks` has no hook and commits without
+checks — rebase it onto main to get the gate back.
+
+To bypass deliberately (not recommended): `git commit --no-verify`
+
+If the hook stops with "Dependencies are not installed", that is not a problem
+with your code — the worktree has no `node_modules`. Run `npm install` and
+commit again.
 
 ### Test Harness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,12 @@ It is also wired to npm's `prepare` script, so plain `npm install` usually does
 it for you. Do not count on that: if your npm config sets `ignore-scripts=true`
 (a reasonable supply-chain precaution, and the setting on Danyel's machine),
 npm skips `prepare` silently and you must run the script yourself. Running it
-twice is harmless.
+twice is harmless — and re-running repairs a hook whose executable bit got
+lost, which git would otherwise skip without saying anything.
+
+If `core.hooksPath` is already set to something else, the script refuses rather
+than clobber what may be a global or organisation-wide setting. It prints what
+is set and tells you to re-run with `--force` if that value is stale.
 
 The path is stored as the relative string `.githooks`, which git resolves
 against whichever working tree is committing. One setting therefore covers the

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "prepare": "sh scripts/install-hooks.sh",
+    "prepare": "sh scripts/install-hooks.sh --warn-only",
     "dev": "vite",
     "harness": "vite --open /test-harness/",
     "build": "tsc --project tsconfig.build.json && vite build",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "prepare": "sh scripts/install-hooks.sh",
     "dev": "vite",
     "harness": "vite --open /test-harness/",
     "build": "tsc --project tsconfig.build.json && vite build",

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -3,8 +3,11 @@
 # Point git at the tracked hooks in .githooks/.
 #
 # Run once per clone:   ./scripts/install-hooks.sh
-# It also runs automatically as npm's "prepare" script, so `npm install`
-# installs the hooks for you.
+# Re-running is harmless, and repairs a hook whose executable bit was lost.
+#
+#   --force      replace a core.hooksPath that is already set to something else
+#   --warn-only  for unattended callers: warn instead of failing when another
+#                hooks path is already configured
 #
 # core.hooksPath is repository-wide config, shared by every worktree. We set it
 # to the RELATIVE path ".githooks", which git resolves against the top of
@@ -14,35 +17,90 @@
 
 set -u
 
-# Never break `npm install` over this.
+WANT=".githooks"
+force=0
+warn_only=0
+
+for arg in "$@"; do
+  case "$arg" in
+    -f | --force) force=1 ;;
+    --warn-only) warn_only=1 ;;
+    -h | --help)
+      sed -n '2,17p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "install-hooks: unknown argument '$arg' (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
 if ! command -v git >/dev/null 2>&1; then
   echo "install-hooks: git not found; skipping hook installation." >&2
   exit 0
 fi
 
-if ! git rev-parse --git-dir >/dev/null 2>&1; then
-  echo "install-hooks: not inside a git repository; skipping hook installation." >&2
+# Everything below works on absolute paths built from the repository root, so
+# that running this from a subdirectory (scripts/, say) behaves identically.
+root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+if [ -z "$root" ]; then
+  echo "install-hooks: not inside a git working tree; skipping hook installation." >&2
   exit 0
 fi
 
 current=$(git config --get core.hooksPath 2>/dev/null || true)
 
-if [ "$current" = ".githooks" ]; then
+# Refuse to silently disable someone else's hooks. core.hooksPath may have been
+# set globally or by an organisation, and clobbering it would turn off hooks
+# this project knows nothing about.
+if [ -n "$current" ] && [ "$current" != "$WANT" ] && [ "$force" -eq 0 ]; then
+  echo "" >&2
+  echo "  install-hooks: NOT installing hooks." >&2
+  echo "" >&2
+  echo "  core.hooksPath is already set to:" >&2
+  echo "      $current" >&2
+  echo "" >&2
+  echo "  That may be a global or organisation-wide setting rather than this" >&2
+  echo "  project's, so this script will not overwrite it on its own." >&2
+  echo "" >&2
+  echo "  If it is stale and you want this project's hooks, re-run with:" >&2
+  echo "      $0 --force" >&2
+  echo "" >&2
+  [ "$warn_only" -eq 1 ] && exit 0
+  exit 1
+fi
+
+if [ "$current" != "$WANT" ]; then
+  if ! git config core.hooksPath "$WANT"; then
+    echo "install-hooks: could not set core.hooksPath; hooks are NOT installed." >&2
+    echo "install-hooks: run 'git config core.hooksPath $WANT' by hand." >&2
+    exit 1
+  fi
+fi
+
+# A branch predating .githooks/ has no hooks to install. core.hooksPath is
+# repository-wide, so leaving it set is still correct for other worktrees.
+if [ ! -d "$root/$WANT" ]; then
+  echo "install-hooks: core.hooksPath set, but $WANT/ does not exist on this" >&2
+  echo "install-hooks: branch, so no hook will run here until you rebase." >&2
   exit 0
 fi
 
-if [ -n "$current" ]; then
-  echo "install-hooks: replacing core.hooksPath '$current' with '.githooks'." >&2
+# Git records the executable bit, but a stray umask, a filesystem that drops
+# modes, or a stale checkout can leave a hook unrunnable -- and git skips a
+# non-executable hook silently, which looks exactly like having no gate at all.
+# So chmod, then assert the result rather than trusting the exit status.
+if ! chmod +x "$root/$WANT"/*; then
+  echo "install-hooks: could not make $WANT/* executable; hooks would be" >&2
+  echo "install-hooks: skipped silently by git. Fix the permissions and re-run." >&2
+  exit 1
 fi
 
-if ! git config core.hooksPath .githooks; then
-  echo "install-hooks: could not set core.hooksPath; hooks are NOT installed." >&2
-  echo "install-hooks: run 'git config core.hooksPath .githooks' by hand." >&2
-  exit 0
+if [ ! -x "$root/$WANT/pre-commit" ]; then
+  echo "install-hooks: $WANT/pre-commit is not executable; git would skip it" >&2
+  echo "install-hooks: silently. Hooks are NOT reliably installed." >&2
+  exit 1
 fi
 
-# Git records the executable bit, but a stray umask or a filesystem that drops
-# modes would leave the hook unrunnable and git would silently skip it.
-chmod +x .githooks/* 2>/dev/null || true
-
-echo "install-hooks: git hooks installed (core.hooksPath = .githooks)."
+echo "install-hooks: git hooks installed (core.hooksPath = $WANT)."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+#
+# Point git at the tracked hooks in .githooks/.
+#
+# Run once per clone:   ./scripts/install-hooks.sh
+# It also runs automatically as npm's "prepare" script, so `npm install`
+# installs the hooks for you.
+#
+# core.hooksPath is repository-wide config, shared by every worktree. We set it
+# to the RELATIVE path ".githooks", which git resolves against the top of
+# whichever worktree is committing -- so one setting covers the main checkout
+# and every present and future worktree, each running the hook checked out on
+# its own branch.
+
+set -u
+
+# Never break `npm install` over this.
+if ! command -v git >/dev/null 2>&1; then
+  echo "install-hooks: git not found; skipping hook installation." >&2
+  exit 0
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "install-hooks: not inside a git repository; skipping hook installation." >&2
+  exit 0
+fi
+
+current=$(git config --get core.hooksPath 2>/dev/null || true)
+
+if [ "$current" = ".githooks" ]; then
+  exit 0
+fi
+
+if [ -n "$current" ]; then
+  echo "install-hooks: replacing core.hooksPath '$current' with '.githooks'." >&2
+fi
+
+if ! git config core.hooksPath .githooks; then
+  echo "install-hooks: could not set core.hooksPath; hooks are NOT installed." >&2
+  echo "install-hooks: run 'git config core.hooksPath .githooks' by hand." >&2
+  exit 0
+fi
+
+# Git records the executable bit, but a stray umask or a filesystem that drops
+# modes would leave the hook unrunnable and git would silently skip it.
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "install-hooks: git hooks installed (core.hooksPath = .githooks)."

--- a/scripts/work-on-issue.sh
+++ b/scripts/work-on-issue.sh
@@ -72,7 +72,10 @@ npm install
 
 # npm's "prepare" script would normally do this, but npm skips it when
 # ignore-scripts is set, so call it directly. Idempotent.
-sh scripts/install-hooks.sh
+if ! sh scripts/install-hooks.sh --warn-only; then
+  echo "warning: git hooks were not installed in this worktree, so commits here"
+  echo "warning: will NOT be checked. See scripts/install-hooks.sh."
+fi
 
 echo -ne "\033]0;${REPO_NAME}: #${ISSUE_NUM}\007"
 

--- a/scripts/work-on-issue.sh
+++ b/scripts/work-on-issue.sh
@@ -65,6 +65,15 @@ echo "Creating worktree for #$ISSUE_NUM at $WORKTREE_PATH"
 git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/main
 cd "$WORKTREE_PATH"
 
+# A fresh worktree has no node_modules, so tests, typecheck and the pre-commit
+# hook all fail confusingly until this runs.
+echo "Installing dependencies in the new worktree..."
+npm install
+
+# npm's "prepare" script would normally do this, but npm skips it when
+# ignore-scripts is set, so call it directly. Idempotent.
+sh scripts/install-hooks.sh
+
 echo -ne "\033]0;${REPO_NAME}: #${ISSUE_NUM}\007"
 
 PROMPT="Work on GitHub issue #$ISSUE_NUM: $TITLE


### PR DESCRIPTION
CLAUDE.md has claimed for months that "a pre-commit hook automatically runs all tests." It didn't. `.git/hooks/pre-commit` held only a shim for beads — the tracker this project dropped two trackers ago — which called a `bd` binary that isn't installed and exited having checked nothing. Several agents have committed believing their work was verified.

## What changed

The hook now runs `npm run typecheck` and the full vitest suite and blocks the commit if either fails. Measured cost: ~0.8s for the typecheck, ~3s for 1517 tests, about 6s total — cheap enough that there's no case for a narrowed subset.

It lives in the tracked `.githooks/` directory, with `core.hooksPath` set to the relative string `.githooks`. That relative path matters: `core.hooksPath` is one repository-wide setting, but git resolves a relative value against whichever working tree is committing, so a single setting covers the main checkout and every worktree, each running the hook on its own branch. Verified in a throwaway repo with two worktrees carrying different hooks.

Setup after a clone is one line:

```bash
./scripts/install-hooks.sh
```

`work-on-issue.sh` now runs `npm install` and installs the hook in each new worktree; it previously did neither.

## Two gotchas

**npm's `prepare` script can't be relied on.** I wired the installer to `prepare`, then tested a fresh clone and it did nothing: `ignore-scripts=true` in `~/.npmrc` makes npm skip `prepare` silently. The wiring stays for contributors without that flag, but the explicit script is the documented step.

**Missing dependencies now give an honest message.** Without `node_modules` the typecheck fails with `Cannot find type definition file for 'vite/client'`, which reads like a code error. The hook checks first and names the directory to run `npm install` in.

## Testing

Exercised against real commits, then discarded: clean commit allowed; failing test blocks with exit 1 and nothing in `git log`; `node_modules` moved aside gives the dependency message; `--no-verify` bypasses; a fresh clone plus `npm install` and `install-hooks.sh` ran all 1517 tests on a probe commit. This branch's own commit was gated by the new hook.

## Notes

Branches that predate `.githooks` have no pre-commit hook until they rebase — but the hook they had was the dead shim, so nothing is lost.

Inert beads shims remain for `pre-push`, `prepare-commit-msg`, `post-checkout` and `post-merge`; they can be removed with `rm -f .git/hooks/{pre-push,prepare-commit-msg,post-checkout,post-merge}{,.backup}`.

Out of scope, found along the way: the test suite prints a wall of `ECONNREFUSED` and happy-dom teardown noise that buries real assertions on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RoXaNgMgb3ZpscWVhp3V9
